### PR TITLE
Only color the first argument

### DIFF
--- a/lib/Log/Any/Plugin/ANSIColor.pm
+++ b/lib/Log/Any/Plugin/ANSIColor.pm
@@ -41,8 +41,9 @@ sub install {
 
             my $old_method = get_old_method($adapter_class, $method_name);
             set_new_method($adapter_class, $method_name, sub {
-                my $self = shift;
-                $self->$old_method(colored([$color], @_));
+                 my $self   = shift;
+                 my $format = shift;
+                 $self->$old_method(colored( [$color], $format), @_ );
             });
         }
     }


### PR DESCRIPTION
...as of the latest versions of Log::Any we can do

        $log->info( "hi there!", { context => 'something' } );

and it will print that context as serialized via Data::Dumper.
Unfortunately, `colored()` stringify all its arguments, so instead of
the dumped objects we get colored HASH0xdeadbeef, which is less than
optimal -- hence limiting ourselves to the first argument.